### PR TITLE
Add option to translate tray to French

### DIFF
--- a/src/utils/Config.ts
+++ b/src/utils/Config.ts
@@ -30,6 +30,14 @@ export function get(app: Electron.App, key?: string) {
   return key ? data[key] : data;
 }
 
+export function getLanguage(app: Electron.App): string {
+  return get(app, 'language') || 'en';
+}
+
+export function setLanguage(app: Electron.App, language: string) {
+  set(app, 'language', language);
+}
+
 function getConfigPath(app: Electron.App) {
   const userDataPath = app.getPath('userData');
   return join(userDataPath, 'config.json');

--- a/src/utils/Tray.ts
+++ b/src/utils/Tray.ts
@@ -6,6 +6,7 @@ import { Menu, Tray } from 'electron';
 import { version } from '../../package.json';
 import { log } from './Log';
 import { win } from './Window';
+import { i18n, changeLanguage } from './i18n';
 
 const iconPath = join(__dirname, '..', 'img', 'tray.png');
 
@@ -14,29 +15,35 @@ export async function init(app: Electron.App, client: import('@xhayper/discord-r
   app?.whenReady().then(() => {
     tray = new Tray(iconPath);
     const contextMenu = Menu.buildFromTemplate([
-      { label: 'Deezer Discord RPC', type: 'normal', click: () => win.show() },
-      { label: `Version: ${version}${process.argv0.includes('node') ? ' (debug)' : ''}`, type: 'normal', enabled: false },
-      { label: 'Check for updates', type: 'normal', click: () => updater() },
+      { label: i18n.t('tray.deezerDiscordRPC'), type: 'normal', click: () => win.show() },
+      { label: `${i18n.t('tray.version')}: ${version}${process.argv0.includes('node') ? ' (debug)' : ''}`, type: 'normal', enabled: false },
+      { label: i18n.t('tray.checkForUpdates'), type: 'normal', click: () => updater() },
       { type: 'separator' },
       {
-        label: 'Tooltip text', type: 'submenu', submenu: [
-          ['App name', 'app_name'],
-          ['App version', 'app_version'],
-          ['App name and version', 'app_name_and_version'],
-          ['Artists song - Song title', 'artists_and_title'],
-          ['Song title - Artists song', 'title_and_artists'],
+        label: i18n.t('tray.tooltipText'), type: 'submenu', submenu: [
+          [i18n.t('tray.appName'), 'app_name'],
+          [i18n.t('tray.appVersion'), 'app_version'],
+          [i18n.t('tray.appNameAndVersion'), 'app_name_and_version'],
+          [i18n.t('tray.artistsAndTitle'), 'artists_and_title'],
+          [i18n.t('tray.titleAndArtists'), 'title_and_artists'],
         ].map(v => ({
           label: v[0], type: 'radio', id: v[1], checked: Config.get(app, 'tooltip_text') === v[1],
           click: (menuItem) => Config.set(app, 'tooltip_text', menuItem.id)
         }))
       },
       {
-        label: 'Don\'t close to tray', type: 'checkbox', checked: Config.get(app, 'dont_close_to_tray'),
+        label: i18n.t('tray.language'), type: 'submenu', submenu: [
+          { label: 'English', type: 'radio', id: 'en', checked: Config.getLanguage(app) === 'en', click: () => changeLanguage(app, 'en') },
+          { label: 'Français', type: 'radio', id: 'fr', checked: Config.getLanguage(app) === 'fr', click: () => changeLanguage(app, 'fr') }
+        ]
+      },
+      {
+        label: i18n.t('tray.dontCloseToTray'), type: 'checkbox', checked: Config.get(app, 'dont_close_to_tray'),
         click: (menuItem) => Config.set(app, 'dont_close_to_tray', menuItem.checked)
       },
       {
         id: 'reconnect',
-        label: 'Reconnect RPC',
+        label: i18n.t('tray.reconnectRPC'),
         type: 'normal',
         visible: false,
         click: () => {
@@ -49,7 +56,7 @@ export async function init(app: Electron.App, client: import('@xhayper/discord-r
       },
       { type: 'separator' },
       {
-        label: 'Quit', type: 'normal', click: async () => {
+        label: i18n.t('tray.quit'), type: 'normal', click: async () => {
           RPC.disconnect().catch(console.error);
           win.close();
           app.quit();

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,50 @@
+import i18next from 'i18next';
+
+i18next.init({
+  lng: 'en',
+  resources: {
+    en: {
+      translation: {
+        tray: {
+          deezerDiscordRPC: 'Deezer Discord RPC',
+          version: 'Version',
+          checkForUpdates: 'Check for updates',
+          tooltipText: 'Tooltip text',
+          appName: 'App name',
+          appVersion: 'App version',
+          appNameAndVersion: 'App name and version',
+          artistsAndTitle: 'Artists and title',
+          titleAndArtists: 'Title and artists',
+          language: 'Language',
+          dontCloseToTray: "Don't close to tray",
+          reconnectRPC: 'Reconnect RPC',
+          quit: 'Quit'
+        }
+      }
+    },
+    fr: {
+      translation: {
+        tray: {
+          deezerDiscordRPC: 'Deezer Discord RPC',
+          version: 'Version',
+          checkForUpdates: 'Vérifier les mises à jour',
+          tooltipText: 'Texte de l\'info-bulle',
+          appName: 'Nom de l\'application',
+          appVersion: 'Version de l\'application',
+          appNameAndVersion: 'Nom et version de l\'application',
+          artistsAndTitle: 'Artistes et titre',
+          titleAndArtists: 'Titre et artistes',
+          language: 'Langue',
+          dontCloseToTray: 'Ne pas fermer dans la barre d\'état',
+          reconnectRPC: 'Reconnecter RPC',
+          quit: 'Quitter'
+        }
+      }
+    }
+  }
+});
+
+export function changeLanguage(app: Electron.App, language: string) {
+  i18next.changeLanguage(language);
+  Config.setLanguage(app, language);
+}


### PR DESCRIPTION
Add French translation support for the tray menu.

* Add `getLanguage` and `setLanguage` functions in `src/utils/Config.ts` to manage language preferences.
* Import `i18n` module and update `init` function in `src/utils/Tray.ts` to use translations for tray menu options and tooltip text.
* Add a new submenu for language selection in the tray menu in `src/utils/Tray.ts`.
* Create `src/utils/i18n.ts` to handle translation logic using `i18next`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Fascinax/deezer-discord-rpc?shareId=XXXX-XXXX-XXXX-XXXX).